### PR TITLE
adds a try-catch block in script processing

### DIFF
--- a/lib/HistoricSync.js
+++ b/lib/HistoricSync.js
@@ -151,13 +151,16 @@ HistoricSync.prototype.getBlockFromFile = function(cb) {
       var to=0;
       t.outs.forEach( function(o) {
 
+        try {
+          var s = new Script(o.s);
+          var addrs = self.sync.txDb.getAddrStr(s);
 
-        var s = new Script(o.s);
-        var addrs = self.sync.txDb.getAddrStr(s);
-
-        // support only for p2pubkey p2pubkeyhash and p2sh
-        if (addrs.length === 1) {
-          objTx.out[to].addrStr = addrs[0];
+          // support only for p2pubkey p2pubkeyhash and p2sh
+          if (addrs.length === 1) {
+            objTx.out[to].addrStr = addrs[0];
+          }
+        } catch (e) {
+          console.log('WARN Could not processs: ' + objTx.txid ,e); 
         }
         to++;
       });


### PR DESCRIPTION
This add a try-catch block to prevent the sync to stop in case a malformed / unknown script is found.
