### PR TITLE
Fix repo URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ bitcoind must be running and must have finished downloading the blockchain **bef
 
   To install Insight API, clone the main repository:
 
-    $ git clone git@github.com:bitpay/insight-api.git && cd insight-api
+    $ git clone https://github.com/bitpay/insight-api && cd insight-api
 
   Install dependencies:
 


### PR DESCRIPTION
The command for git-cloning the repo is using a Git URL with read/write access, which doesn't work for people without write access to the repo.
