### PR TITLE
Watch for BITCOIND_P2P_HOST for different server than BITCOIND_HOST

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -71,6 +71,7 @@ var bitcoindConf = {
   host: process.env.BITCOIND_HOST || '127.0.0.1',
   port: process.env.BITCOIND_PORT || b_port,
   p2pPort: process.env.BITCOIND_P2P_PORT || p2p_port,
+  p2pHost: process.env.BITCOIND_P2P_HOST || process.env.BITCOIND_HOST || '127.0.0.1',
   dataDir: dataDir,
   // DO NOT CHANGE THIS!
   disableAgent: true

--- a/lib/PeerSync.js
+++ b/lib/PeerSync.js
@@ -27,7 +27,7 @@ function PeerSync(opts) {
 
 PeerSync.prototype.load_peers = function() {
   this.peerdb = [{
-    ipv4: config.bitcoind.host,
+    ipv4: config.bitcoind.p2pHost,
     port: config.bitcoind.p2pPort
   }];
 


### PR DESCRIPTION
Insight will not p2p_sync when _maxconnections_ is set in the bitcoind.conf
`{ '0': 'connecting to 127.0.0.1:18333' }`
`{ '0': 'disconnected from peer 127.0.0.1:18333' }`

This issue was discovered troubleshooting random sync issues. 
