### PR TITLE
Updated package.json 2 specify leveldown ver0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "connect-ratelimit": "git://github.com/dharmafly/connect-ratelimit.git#0550eff209c54f35078f46445000797fa942ab97",
     "express": "~3.4.7",
     "glob": "*",
-    "leveldown": "*",
+    "leveldown": "0.10.0",
     "levelup": "*",
     "moment": "~2.5.0",
     "preconditions": "^1.0.7",


### PR DESCRIPTION
The newer versions of leveldown (i.e. > 0.10.0) seem to be giving dependency errors that explicitly request version 0.10.0. After installing leveldown 0.10.0 errors desist.
