### PR TITLE
config/config.js

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -11,7 +11,7 @@ var rootPath = path.normalize(__dirname + '/..'),
   b_port,
   p2p_port;
 
-var packageStr = fs.readFileSync('../package.json');
+var packageStr = fs.readFileSync(rootPath + '/package.json');
 var version = JSON.parse(packageStr).version;
 
 


### PR DESCRIPTION
fix a bug

``` js
var packageStr = fs.readFileSync('package.json');
// =>
var packageStr = fs.readFileSync('../package.json');
```
