### PR TITLE
Bug fix for #199

### DIFF
--- a/lib/BlockDb.js
+++ b/lib/BlockDb.js
@@ -335,7 +335,7 @@ BlockDb.prototype._fillConfirmationsOneSpent = function(o, chainHeight, cb) {
             o.spentTxId = oi.spentTxId;
             o.index = oi.index;
             o.spentIsConfirmed = chainHeight >= height;
-            o.spentConfirmations = chainHeight - height;
+            o.spentConfirmations = chainHeight - height +1;
           }
           return e_c();
         });
@@ -345,7 +345,7 @@ BlockDb.prototype._fillConfirmationsOneSpent = function(o, chainHeight, cb) {
       if (err) return cb(err);
       if (height >=0 ) {
         o.spentIsConfirmed = chainHeight >= height;
-        o.spentConfirmations = chainHeight - height;
+        o.spentConfirmations = chainHeight - height +1;
       }
       return cb();
     });
@@ -358,7 +358,7 @@ BlockDb.prototype._fillConfirmationsOne = function(o, chainHeight, cb) {
     if (err) return cb(err);
     if (height>=0) {
       o.isConfirmed = chainHeight >= height;
-      o.confirmations = chainHeight - height;
+      o.confirmations = chainHeight - height +1;
       return self._fillConfirmationsOneSpent(o,chainHeight,cb);
     }
     else return cb();


### PR DESCRIPTION
Proper way of counting confirmed transactions is : Height of longest chain - Height of chain for the block containing the transaction + 1
