### PR TITLE
Fix confirmation info for multiple spent attempts

### DIFF
--- a/lib/BlockDb.js
+++ b/lib/BlockDb.js
@@ -329,10 +329,10 @@ BlockDb.prototype._fillConfirmationsOneSpent = function(o, chainHeight, cb) {
     async.eachLimit(o.multipleSpentAttempts, CONCURRENCY,
       function(oi, e_c) {
         // Only one will be confirmed
-        self.getBlockForTx(oi.spentTxId, function(err, hash, height) {
+        self.getBlockForTx(oi.txid, function(err, hash, height) {
           if (err) return;
           if (height>=0) {
-            o.spentTxId = oi.spentTxId;
+            o.spentTxId = oi.txid;
             o.index = oi.index;
             o.spentIsConfirmed = chainHeight >= height;
             o.spentConfirmations = chainHeight - height +1;


### PR DESCRIPTION
Use the correct property when going over multiple spent attempts.
