### PR TITLE
fix confirm URL on copay

### DIFF
--- a/plugins/emailstore.js
+++ b/plugins/emailstore.js
@@ -120,7 +120,7 @@
     ) + globalConfig.apiPrefix + '/email/validate';
 
     emailPlugin.redirectUrl = (
-      config.redirectUrl || 'https://copay.io/in/app?confirmed=true'
+      config.redirectUrl || 'https://copay.io/in/app#!/confirmed'
     );
   };
 
@@ -149,6 +149,8 @@
    */
   emailPlugin.sendVerificationEmail = function(email, secret) {
     var confirmUrl = emailPlugin.makeConfirmUrl(email, secret);
+
+    logger.debug('ConfirmUrl:',confirmUrl);
 
     async.series([
 


### PR DESCRIPTION
Better URL for confirmation, according to:
https://github.com/bitpay/copay/blob/master/js/controllers/home.js#L10
