### PR TITLE
Fix for #63

### DIFF
--- a/lib/BlockExtractor.js
+++ b/lib/BlockExtractor.js
@@ -62,10 +62,15 @@ BlockExtractor.prototype.readCurrentFileSync = function() {
   var stats = fs.statSync(fname);
 
   var size = stats.size;
-
+  var mb = parseInt(size/1024/1024);
+  
   console.log('Reading Blockfile %s [%d MB]',
-            fname, parseInt(size/1024/1024));
-
+            fname, mb);
+            
+  if(mb > 1023)
+    throw new Error('CRITICAL ERROR: file size greater than 1023MB, use cat blk*.dat > bootstrap.dat to create new '
+                          + 'dat files @128MB. (https://github.com/bitpay/insight-api/issues/35)');
+    
   var fd = fs.openSync(fname, 'r');
 
   var buffer = new Buffer(size);


### PR DESCRIPTION
fix for issue #63 In old bitcoind, .dat files seems to be bigger that the actual 128MB, which could cause errors on insight-api