### PR TITLE
fix BlockDb and TransactionDb import in blocks controller

### DIFF
--- a/app/controllers/blocks.js
+++ b/app/controllers/blocks.js
@@ -4,12 +4,9 @@
  * Module dependencies.
  */
 var common = require('./common'),
-  async = require('async'),
-  BlockDb = require('../../lib/BlockDb'),
-  TransactionDb = require('../../lib/TransactionDb');
-
-var bdb = new BlockDb();
-var tdb = new TransactionDb();
+var async = require('async');
+var bdb = require('./BlockDb').default();
+var tdb = require('./TransactionDb').default();
 
 /**
  * Find block by hash ...


### PR DESCRIPTION
In blocks controller `BlockDb` and `TransactionDb` creates with `new` instead calling `default`. This PR must fix #287. As I understand, in blocks controller after first calling `getTip` method `cachedTip` in bdb can't be changed, because `setTip` will never be called for local instance.