### PR TITLE
Opt/post txs

### DIFF
--- a/app/controllers/addresses.js
+++ b/app/controllers/addresses.js
@@ -127,23 +127,24 @@ exports.multitxs = function(req, res, next) {
     txs = _.uniq(_.flatten(txs), 'txid');
     var nbTxs = txs.length;
 
-    if ( _.isUndefined(from) && _.isUndefined(to)) {
+    if (_.isUndefined(from) && _.isUndefined(to)) {
       from = 0;
       to = MAX_BATCH_SIZE;
     }
-
-    if ( ! _.isUndefined(from) && _.isUndefined(to))
+    if (!_.isUndefined(from) && _.isUndefined(to))
       to = from + MAX_BATCH_SIZE;
 
-    if ( ! _.isUndefined(from) && ! _.isUndefined(to) && to - from > MAX_BATCH_SIZE)
+    if (!_.isUndefined(from) && !_.isUndefined(to) && to - from > MAX_BATCH_SIZE)
       to = from + MAX_BATCH_SIZE;
+
+    if (from < 0) from = 0;
+    if (to > nbTxs) tx = nbTxs;
 
     txs.sort(function(a, b) {
       return (b.ts || b.ts) - (a.ts || a.ts);
     });
-    var start = Math.max(from || 0, 0);
-    var end = Math.min(to || nbTxs, nbTxs);
-    txs = txs.slice(start, end);
+
+    txs = txs.slice(from, to);
 
     var txIndex = {};
     _.each(txs, function(tx) {

--- a/app/controllers/addresses.js
+++ b/app/controllers/addresses.js
@@ -138,7 +138,9 @@ exports.multitxs = function(req, res, next) {
       to = from + MAX_BATCH_SIZE;
 
     if (from < 0) from = 0;
-    if (to > nbTxs) tx = nbTxs;
+    if (to < 0) to = 0;
+    if (from > nbTxs) from = nbTxs;
+    if (to > nbTxs) to = nbTxs;
 
     txs.sort(function(a, b) {
       return (b.ts || b.ts) - (a.ts || a.ts);

--- a/app/controllers/addresses.js
+++ b/app/controllers/addresses.js
@@ -139,9 +139,12 @@ exports.multitxs = function(req, res, next) {
       txIndex[tx.txid] = tx;
     });
 
-    async.each(txs, function(tx, callback) {
+    async.eachLimit(txs, 5, function(tx, callback) {
       tDb.fromIdWithInfo(tx.txid, function(err, tx) {
-        if (err) console.log(err);
+        if (err) {
+          console.log(err);
+          return common.handleErrors(err, res);
+        }
         if (tx && tx.info) {
           txIndex[tx.txid].info = tx.info;
         }

--- a/config/express.js
+++ b/config/express.js
@@ -28,7 +28,8 @@ module.exports = function(app, historicSync, peerSync) {
   app.enable('jsonp callback');
   app.use(config.apiPrefix, setHistoric);
   app.use(config.apiPrefix, setPeer);
-  app.use(express.logger('dev'));
+  app.use(require('morgan')(':remote-addr :date[iso] ":method :url" :status :res[content-length] :response-time ":user-agent" '));
+  
   app.use(express.json());
   app.use(express.urlencoded());
   app.use(express.methodOverride());

--- a/lib/TransactionDb.js
+++ b/lib/TransactionDb.js
@@ -17,7 +17,7 @@ var ADDR_PREFIX = 'txa2-'; //txa-<addr>-<tsr>-<txid>-<n>
 
 // TODO: use bitcore networks module
 var genesisTXID = '4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b';
-var CONCURRENCY = 10;
+var CONCURRENCY = 5;
 var DEFAULT_SAFE_CONFIRMATIONS = 6;
 
 var MAX_OPEN_FILES = 500;
@@ -448,6 +448,9 @@ TransactionDb.prototype._parseAddrData = function(k, data, ignoreCache) {
   return item;
 };
 
+
+// opts.dontFillSpent
+
 TransactionDb.prototype.fromAddr = function(addr, opts, cb) {
   opts = opts || {};
   var self = this;
@@ -470,6 +473,10 @@ TransactionDb.prototype.fromAddr = function(addr, opts, cb) {
     })
     .on('error', cb)
     .on('end', function() {
+      if (opts.dontFillSpent) {
+        return cb(null, ret)
+      }
+
       async.eachLimit(ret.filter(function(x) {
           return !x.spentIsConfirmed;
         }), CONCURRENCY, function(o, e_c) {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "async": "*",
     "base58-native": "0.1.2",
     "bignum": "*",
-    "bitauth": "^0.1.1",
+    "morgan": "*",
     "bitcore": "git://github.com/bitpay/bitcore.git#aa41c70cff2583d810664c073a324376c39c8b36",
     "bufferput": "git://github.com/bitpay/node-bufferput.git",
     "buffertools": "*",


### PR DESCRIPTION
- adds limits to RPC concurrency
- better HTTP response code if RPC comm to bitcoind failed
- enforce limits (to up to 100 txs) to POST request to /api/addrs/txs 
- better ACCESS LOG format (using morgan)