### PR TITLE
Adds batch request support for block and transaction methods, plus a bit more data to transactions

### DIFF
--- a/app/controllers/blocks.js
+++ b/app/controllers/blocks.js
@@ -67,7 +67,7 @@ exports.blockIndex = multi(function(height, cb) {
   bdb.blockIndex(height, function(err, hashStr) {
     if (err) {
       console.log(err);
-      cb('Bad Request'); // TODO
+      return cb(err); // TODO
     } else {
       cb(null, hashStr);
     }
@@ -82,11 +82,11 @@ exports.blockHeaderByIndex = multi(function(height, cb) {
   bdb.blockIndex(height, function(err, hashStr) {
     if (err) {
       console.log(err);
-      cb('Bad Request');
+      return cb(err);
     } else {
       bdb.fromHashWithInfo(hashStr.blockHash, function(err, block) {
         if (err || !block)
-          cb(err);
+          return cb(err);
         else {
           delete block.info.tx;
           cb(null, block.info);

--- a/app/controllers/common.js
+++ b/app/controllers/common.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var async       = require('async');
+
 exports.notReady = function (err, res, p) {
   res.status(503).send('Server not yet ready. Sync Percentage:' + p);
 };
@@ -17,3 +19,21 @@ exports.handleErrors = function (err, res) {
     res.status(404).send('Not found');
   }
 };
+
+exports.multi = function(f, outkey) {
+  return function(req, res, next, inputdata) {
+    var inputs;
+    if (inputdata.indexOf(',') >= 0) {
+      inputs = inputdata.split(',');
+    }
+    else inputs = [inputdata];
+    async.mapSeries(inputs, f, function(err, results) {
+	if (err)
+          return exports.handleErrors(err, res);
+        req[outkey] = results;
+  	if (req[outkey].length == 1)
+  	  req[outkey] = req[outkey][0]
+          return next();
+    });
+  };
+}

--- a/app/controllers/common.js
+++ b/app/controllers/common.js
@@ -28,8 +28,9 @@ exports.multi = function(f, outkey) {
     }
     else inputs = [inputdata];
     async.mapSeries(inputs, f, function(err, results) {
-	if (err)
+	if (err) {
           return exports.handleErrors(err, res);
+	}
         req[outkey] = results;
   	if (req[outkey].length == 1)
   	  req[outkey] = req[outkey][0]

--- a/app/controllers/transactions.js
+++ b/app/controllers/transactions.js
@@ -41,16 +41,15 @@ exports.send = function(req, res) {
   });
 };
 
-exports.rawTransaction = function (req, res, next, txid) {
+exports.rawTransaction = multi(function(txid, cb) {
     bitcoreRpc.getRawTransaction(txid, function (err, transaction) {
         if (err || !transaction)
-            return common.handleErrors(err, res);
+            return cb(err);
         else {
-            req.rawTransaction = { 'rawtx': transaction.result };
-            return next();
+            return cb(null, transaction.result);
         }
     });
-};
+}, 'rawTransaction');
 
 /**
  * Find transaction by hash ...

--- a/app/controllers/transactions.js
+++ b/app/controllers/transactions.js
@@ -6,6 +6,7 @@
 var Address     = require('../models/Address');
 var async       = require('async');
 var common      = require('./common');
+var multi       = common.multi;
 var util        = require('util');
 
 var Rpc         = require('../../lib/Rpc');
@@ -54,22 +55,19 @@ exports.rawTransaction = function (req, res, next, txid) {
 /**
  * Find transaction by hash ...
  */
-exports.transaction = function(req, res, next, txid) {
+exports.transaction = multi(function(txid, cb) {
+    tDb.fromIdWithInfo(txid, function(err, tx) {
+      if (err || ! tx)
+        return cb(err);
 
-  tDb.fromIdWithInfo(txid, function(err, tx) {
-    if (err || ! tx)
-      return common.handleErrors(err, res);
+      bdb.fillVinConfirmations(tx.info, function(err) {
+        if (err)
+          return cb(err);
+        return cb(null, tx.info);
+      });
 
-    bdb.fillVinConfirmations(tx.info, function(err) {
-      if (err)
-        return common.handleErrors(err, res);
-
-      req.transaction = tx.info;
-      return next();
     });
-
-  });
-};
+}, 'transaction');
 
 
 /**

--- a/config/routes.js
+++ b/config/routes.js
@@ -38,6 +38,8 @@ module.exports = function(app) {
   // Raw Routes
   app.get(apiPrefix + '/rawtx/:txid', transactions.showRaw);
   app.param('txid', transactions.rawTransaction);
+  app.get(apiPrefix + '/rawmultitx/:txids', transactions.showRaw);
+  app.param('txids', transactions.rawTransaction);
 
   // Address routes
   var addresses = require('../app/controllers/addresses');

--- a/config/routes.js
+++ b/config/routes.js
@@ -17,8 +17,14 @@ module.exports = function(app) {
   app.get(apiPrefix + '/block/:blockHash', blocks.show);
   app.param('blockHash', blocks.block);
 
-  app.get(apiPrefix + '/block-index/:height', blocks.blockindex);
-  app.param('height', blocks.blockindex);
+  app.get(apiPrefix + '/blockheader/:blockHeaderHash', blocks.show);
+  app.param('blockHeaderHash', blocks.blockHeader);
+
+  app.get(apiPrefix + '/block-index/:height', blocks.showBlockHash);
+  app.param('height', blocks.blockIndex);
+
+  app.get(apiPrefix + '/blockheader-by-index/:headerHeight', blocks.show);
+  app.param('headerHeight', blocks.blockHeaderByIndex);
 
   // Transaction routes
   var transactions = require('../app/controllers/transactions');
@@ -26,6 +32,8 @@ module.exports = function(app) {
   app.param('txid', transactions.transaction);
   app.get(apiPrefix + '/txs', transactions.list);
   app.post(apiPrefix + '/tx/send', transactions.send);
+  app.get(apiPrefix + '/multitx/:txids', transactions.show);
+  app.param('txids', transactions.transaction);
 
   // Raw Routes
   app.get(apiPrefix + '/rawtx/:txid', transactions.showRaw);

--- a/lib/BlockDb.js
+++ b/lib/BlockDb.js
@@ -427,6 +427,7 @@ BlockDb.prototype.fillVinConfirmations = function(tx, cb) {
     if (!vin) return cb();
 
     async.eachLimit(vin, CONCURRENCY, function(v, e_c) {
+      tx.confirmedIn = height - tx.confirmations + 1;
       self._fillConfirmationsOneVin(v, height, e_c);
     }, cb);
   });

--- a/lib/BlockDb.js
+++ b/lib/BlockDb.js
@@ -382,6 +382,7 @@ BlockDb.prototype._fillConfirmationsOneVin = function(o, chainHeight, cb) {
       o.confirmations = chainHeight - height + 1;
     }
     o.unconfirmedInput = ! o.isConfirmed;
+    o.confirmedIn = height;
     return cb();
   });
 };

--- a/lib/TransactionDb.js
+++ b/lib/TransactionDb.js
@@ -179,9 +179,14 @@ TransactionDb.prototype._fillSpent = function(info, cb) {
     });
 };
 
+var valToSat = function(x) { return parseInt(x.replace('.', '')) }
 
 TransactionDb.prototype._fillOutpoints = function(txInfo, cb) {
   var self = this;
+
+  for (var i = 0; i < txInfo.vout.length; i++) {
+    txInfo.vout[i].valueSat = valToSat(txInfo.vout[i].value);
+  }
 
   if (!txInfo || txInfo.isCoinBase) return cb();
 
@@ -227,15 +232,16 @@ TransactionDb.prototype._fillOutpoints = function(txInfo, cb) {
       });
     },
     function() {
-      if (!incompleteInputs) {
-        txInfo.valueIn = valueIn / util.COIN;
-        txInfo.fees = (valueIn - (txInfo.valueOut * util.COIN)).toFixed(0) / util.COIN;
-      } else {
-        txInfo.incompleteInputs = 1;
-      }
-      return cb();
+        if (!incompleteInputs) {
+          txInfo.valueIn = valueIn / util.COIN;
+          txInfo.fees = (valueIn - (txInfo.valueOut * util.COIN)).toFixed(0) / util.COIN;
+        } else {
+          txInfo.incompleteInputs = 1;
+        }
+        return cb();
     });
 };
+
 
 TransactionDb.prototype._getInfo = function(txid, next) {
   var self = this;
@@ -243,6 +249,9 @@ TransactionDb.prototype._getInfo = function(txid, next) {
   Rpc.getTxInfo(txid, function(err, txInfo) {
     if (err) return next(err);
     self._fillOutpoints(txInfo, function() {
+      for (var i = 0; i < txInfo.vout.length; i++) {
+        if (!txInfo.vout[i].valueSat) throw("Boo no valuesat: "+JSON.stringify(txInfo.vout[i])+" "+i+" "+txInfo.txid)
+      }
       self._fillSpent(txInfo, function() {
         return next(null, txInfo);
       });

--- a/lib/TransactionDb.js
+++ b/lib/TransactionDb.js
@@ -184,11 +184,13 @@ var valToSat = function(x) { return parseInt(x.replace('.', '')) }
 TransactionDb.prototype._fillOutpoints = function(txInfo, cb) {
   var self = this;
 
+  if (!txInfo) return cb();
+
   for (var i = 0; i < txInfo.vout.length; i++) {
     txInfo.vout[i].valueSat = valToSat(txInfo.vout[i].value);
   }
 
-  if (!txInfo || txInfo.isCoinBase) return cb();
+  if (txInfo.isCoinBase) return cb();
 
   var valueIn = 0;
   var incompleteInputs = 0;
@@ -249,9 +251,6 @@ TransactionDb.prototype._getInfo = function(txid, next) {
   Rpc.getTxInfo(txid, function(err, txInfo) {
     if (err) return next(err);
     self._fillOutpoints(txInfo, function() {
-      for (var i = 0; i < txInfo.vout.length; i++) {
-        if (!txInfo.vout[i].valueSat) throw("Boo no valuesat: "+JSON.stringify(txInfo.vout[i])+" "+i+" "+txInfo.txid)
-      }
       self._fillSpent(txInfo, function() {
         return next(null, txInfo);
       });


### PR DESCRIPTION
We needed to do this locally in order to help users generate their genesis blocks for ethereum; making requests one at a time proved to be much too slow. Hope it can help you guys.