### PR TITLE
Proposal: Allow querying multiple address info

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -35,6 +35,8 @@ module.exports = function(app) {
   var addresses = require('../app/controllers/addresses');
   app.get(apiPrefix + '/addr/:addr', addresses.show);
   app.get(apiPrefix + '/addr/:addr/utxo', addresses.utxo);
+  app.get(apiPrefix + '/addrs/:addrs/info', addresses.multishow);
+  app.post(apiPrefix + '/addrs/info', addresses.multishow);
   app.get(apiPrefix + '/addrs/:addrs/utxo', addresses.multiutxo);
   app.post(apiPrefix + '/addrs/utxo', addresses.multiutxo);
   app.get(apiPrefix + '/addrs/:addrs/txs', addresses.multitxs);


### PR DESCRIPTION
Currently, there is `/api/addr/[:addr][?noTxList=1&noCache=1]` which can query 1 single address.

I would like to query a list of 20 or so addresses so that I may see just if they have any related transactions. This is useful for implementations of BIP44 etc. and any other BIP32 chains with gap limits that need to know which addresses to generate.

My proposal is the following:

`/api/addrs/[:addrs]/info[?noTxList=1&noCache=1]`
`/api/addrs/info`

If there are performance issues / concerns, I think forcing noTxList=1 would be OK, as someone looking for all the transactions could use the tx api call.

If there are other places where code needs to be implemented, please let me know.

For now this is a WIP / proposal.