### PR TITLE
Adding block height to transaction data

### DIFF
--- a/app/controllers/transactions.js
+++ b/app/controllers/transactions.js
@@ -65,15 +65,11 @@ exports.transaction = function(req, res, next, txid) {
         return common.handleErrors(err, res);
 
       req.transaction = tx.info;   
-      console.log("getHeight(" + tx.info.blockhash );
       if(tx.info.blockhash) {
         bdb.getHeight(tx.info.blockhash , function(err, height) {
           if (err) return cb(err);
-          console.log("height="+height);
           tx.info.height = height;
-
           return next();
-
         });
       } else {
         return next();

--- a/app/controllers/transactions.js
+++ b/app/controllers/transactions.js
@@ -64,8 +64,20 @@ exports.transaction = function(req, res, next, txid) {
       if (err)
         return common.handleErrors(err, res);
 
-      req.transaction = tx.info;
-      return next();
+      req.transaction = tx.info;   
+      console.log("getHeight(" + tx.info.blockhash );
+      if(tx.info.blockhash) {
+        bdb.getHeight(tx.info.blockhash , function(err, height) {
+          if (err) return cb(err);
+          console.log("height="+height);
+          tx.info.height = height;
+
+          return next();
+
+        });
+      } else {
+        return next();
+      }
     });
 
   });


### PR DESCRIPTION
I needed block height information in transaction data cause otherwise i needed another http call to know the block height (i have the number of confirmations but i don't have the last block height)
I am not sure if it's the right place and the right way to achieve this but it's working at:
http://vr4.synaptica.info:3000/api/tx/c486edda051eb792ddf8e484e087ba5fecc06279c270868e58c1b1dfdab39a12