### PR TITLE
Opt/script pub key cache

### DIFF
--- a/lib/TransactionDb.js
+++ b/lib/TransactionDb.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var imports = require('soop').imports();
+var _ = require('lodash');
 
 
 
@@ -115,9 +116,9 @@ TransactionDb.prototype.fromTxId = function(txid, cb) {
 
   // outs.
   db.createReadStream({
-    start: k,
-    end: k + '~'
-  })
+      start: k,
+      end: k + '~'
+    })
     .on('data', function(data) {
       var k = data.key.split('-');
       var v = data.value.split(':');
@@ -135,9 +136,9 @@ TransactionDb.prototype.fromTxId = function(txid, cb) {
 
       var k = SPENT_PREFIX + txid + '-';
       db.createReadStream({
-        start: k,
-        end: k + '~'
-      })
+          start: k,
+          end: k + '~'
+        })
         .on('data', function(data) {
           var k = data.key.split('-');
           var j = idx[parseInt(k[2])];
@@ -164,9 +165,9 @@ TransactionDb.prototype._fillSpent = function(info, cb) {
 
   var k = SPENT_PREFIX + info.txid + '-';
   db.createReadStream({
-    start: k,
-    end: k + '~'
-  })
+      start: k,
+      end: k + '~'
+    })
     .on('data', function(data) {
       var k = data.key.split('-');
       self._addSpentInfo(info.vout[k[2]], k[3], k[4], data.value);
@@ -247,8 +248,8 @@ TransactionDb.prototype._getInfo = function(txid, next, opts) {
 
     self._fillOutpoints(txInfo, function() {
 
-      if (opts.noExtraInfo) 
-        return next(null,txInfo);
+      if (opts.noExtraInfo)
+        return next(null, txInfo);
 
       self._fillSpent(txInfo, function() {
         return next(null, txInfo);
@@ -301,15 +302,15 @@ TransactionDb.prototype.fromTxIdN = function(txid, n, cb, opts) {
       };
     }
 
-    if (opts.noExtraInfo) 
+    if (opts.noExtraInfo)
       return cb(null, ret);
 
     // spent?
     var k = SPENT_PREFIX + txid + '-' + n + '-';
     db.createReadStream({
-      start: k,
-      end: k + '~'
-    })
+        start: k,
+        end: k + '~'
+      })
       .on('data', function(data) {
         var k = data.key.split('-');
         self._addSpentInfo(ret, k[3], k[4], data.value);
@@ -328,9 +329,9 @@ TransactionDb.prototype.deleteCacheForAddress = function(addr, cb) {
   var k = ADDR_PREFIX + addr + '-';
   var dbScript = [];
   db.createReadStream({
-    start: k,
-    end: k + '~'
-  })
+      start: k,
+      end: k + '~'
+    })
     .on('data', function(data) {
       var v = data.value.split(':');
       dbScript.push({
@@ -391,25 +392,28 @@ TransactionDb.prototype.cacheConfirmations = function(txouts, cb) {
 
 
 TransactionDb.prototype.cacheScriptPubKey = function(txouts, cb) {
-   console.log('[TransactionDb.js.381:cacheScriptPubKey:]'); //TODO
+  //  console.log('[TransactionDb.js.381:cacheScriptPubKey:]'); //TODO
   var self = this;
   var dbScript = [];
-  for (var ii in txouts) {
-    var txout = txouts[ii];
+  _.each(txouts, function(txout) {
+
     //everything already cached?
-    if (txout.scriptPubKeyCached || txout.spentTxId) {
-      continue;
-    }
+    if (txout.scriptPubKeyCached || txout.spentTxId)
+      return;
+
+    // not hard confirmed ?
+    if (!txout.isConfirmedCached && !txout.confirmedWillBeCached)
+      return;
 
     if (txout.scriptPubKey) {
-      var infoToCache = [txout.value_sat, (txout.isConfirmedCached || txout.confirmedWillBeCached) ? 1 : 0, txout.scriptPubKey];
+      var infoToCache = [txout.value_sat, 1, txout.scriptPubKey];
       dbScript.push({
         type: 'put',
         key: txout.key,
         value: infoToCache.join(':'),
       });
     }
-  }
+  });
   db.batch(dbScript, cb);
 };
 
@@ -466,10 +470,10 @@ TransactionDb.prototype.fromAddr = function(addr, opts, cb) {
   var unique = {};
 
   db.createReadStream({
-    start: k,
-    end: k + '~',
-    limit: opts.txLimit > 0 ? opts.txLimit : -1, // -1 means not limit
-  })
+      start: k,
+      end: k + '~',
+      limit: opts.txLimit > 0 ? opts.txLimit : -1, // -1 means not limit
+    })
     .on('data', function(data) {
       var k = data.key.split('-');
       var index = k[3] + k[4];
@@ -495,9 +499,9 @@ TransactionDb.prototype.fromAddr = function(addr, opts, cb) {
         }), CONCURRENCY, function(o, e_c) {
           var k = SPENT_PREFIX + o.txid + '-' + o.index + '-';
           db.createReadStream({
-            start: k,
-            end: k + '~'
-          })
+              start: k,
+              end: k + '~'
+            })
             .on('data', function(data) {
               var k = data.key.split('-');
               self._addSpentInfo(o, k[3], k[4], data.value);
@@ -573,8 +577,9 @@ TransactionDb.prototype.fillScriptPubKey = function(txouts, cb) {
       return a_c();
     });
   }, function() {
-    if (!allCached) 
-      self.cacheScriptPubKey(txouts, cb);
+    if (allCached)
+      return cb();
+    self.cacheScriptPubKey(txouts, cb);
   });
 };
 
@@ -593,14 +598,14 @@ TransactionDb.prototype.removeFromTxId = function(txid, cb) {
       },
       function(c) {
         db.createReadStream({
-          start: SPENT_PREFIX + txid + '-',
-          end: SPENT_PREFIX + txid + '~'
-        })
+            start: SPENT_PREFIX + txid + '-',
+            end: SPENT_PREFIX + txid + '~'
+          })
           .pipe(
             db.createWriteStream({
               type: 'del'
             })
-        ).on('close', c);
+          ).on('close', c);
       }
     ],
     function(err) {
@@ -722,10 +727,10 @@ TransactionDb.prototype.checkVersion02 = function(cb) {
   var k = 'txa-';
   var isV2 = 1;
   db.createReadStream({
-    start: k,
-    end: k + '~',
-    limit: 1,
-  })
+      start: k,
+      end: k + '~',
+      limit: 1,
+    })
     .on('data', function(data) {
       isV2 = 0;
     })
@@ -741,9 +746,9 @@ TransactionDb.prototype.migrateV02 = function(cb) {
   var c2 = 0;
   var N = 50000;
   db.createReadStream({
-    start: k,
-    end: k + '~'
-  })
+      start: k,
+      end: k + '~'
+    })
     .on('data', function(data) {
       var k = data.key.split('-');
       var v = data.value.split(':');

--- a/lib/TransactionDb.js
+++ b/lib/TransactionDb.js
@@ -391,7 +391,7 @@ TransactionDb.prototype.cacheConfirmations = function(txouts, cb) {
 
 
 TransactionDb.prototype.cacheScriptPubKey = function(txouts, cb) {
-  //  console.log('[TransactionDb.js.381:cacheScriptPubKey:]'); //TODO
+   console.log('[TransactionDb.js.381:cacheScriptPubKey:]'); //TODO
   var self = this;
   var dbScript = [];
   for (var ii in txouts) {
@@ -560,9 +560,11 @@ TransactionDb.prototype.getStandardizedTx = function(tx, time, isCoinBase) {
 
 TransactionDb.prototype.fillScriptPubKey = function(txouts, cb) {
   var self = this;
+  var allCached = true;
   // Complete utxo info
   async.eachLimit(txouts, CONCURRENCY, function(txout, a_c) {
     if (txout.scriptPubKeyCached) return a_c();
+    allCached = false;
 
     self.fromIdInfoSimple(txout.txid, function(err, info) {
       if (!info || !info.vout) return a_c(err);
@@ -571,7 +573,8 @@ TransactionDb.prototype.fillScriptPubKey = function(txouts, cb) {
       return a_c();
     });
   }, function() {
-    self.cacheScriptPubKey(txouts, cb);
+    if (!allCached) 
+      self.cacheScriptPubKey(txouts, cb);
   });
 };
 

--- a/lib/TransactionDb.js
+++ b/lib/TransactionDb.js
@@ -562,6 +562,8 @@ TransactionDb.prototype.fillScriptPubKey = function(txouts, cb) {
   var self = this;
   // Complete utxo info
   async.eachLimit(txouts, CONCURRENCY, function(txout, a_c) {
+    if (txout.scriptPubKeyCached) return a_c();
+
     self.fromIdInfoSimple(txout.txid, function(err, info) {
       if (!info || !info.vout) return a_c(err);
 


### PR DESCRIPTION
 - this use the already saved 'scriptPubKey' Cache
 - the cache is only saved with confirmation > safe_confirmations (that behavior was not changed)

This speeds up ~ 50% getAddrs from queries with ~ 1000 addr and up to 20x queries with 2-3 addresses and 1000s of utxos in them.