### PR TITLE
Optimize block list page.

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -135,16 +135,34 @@ BlockController.prototype.list = function(req, res) {
     async.mapSeries(
       hashes,
       function(hash, next) {
-        self.node.getBlock(hash, function(err, block) {
+        self.node.services.bitcoind.getBlock(hash, function(err, blockBuffer) {
           if(err) {
             return next(err);
           }
+          var br = new bitcore.encoding.BufferReader(blockBuffer);
+          // take a shortcut to get number of transactions and the blocksize.
+          // Also reads the coinbase transaction and only that.
+          // Old code parsed all transactions in every block _and_ then encoded
+          // them all back together to get the binary size of the block.
+          // FIXME: This code might still read the whole block. Fixing that
+          // would require changes in bitcore-node.
+          var header = bitcore.BlockHeader.fromBufferReader(br);
+          var info = {};
+          var txlength = br.readVarintNum();
+          info.transactions = [bitcore.Transaction().fromBufferReader(br)];
 
-          var info = self.node.services.bitcoind.getBlockIndex(hash);
-          block.__height = info.height;
+          var index = self.node.services.bitcoind.getBlockIndex(hash);
+          var block = {
+              height: index.height,
+              size: blockBuffer.length,
+              hash: hash,
+              time: header.time,
+              txlength: txlength,
+              poolInfo: self.getPoolInfo(info)
+          };
 
-          if(moreTs > block.header.timestamp) {
-            moreTs = block.header.timestamp;
+          if(moreTs > header.timestamp) {
+            moreTs = header.timestamp;
           }
 
           return next(null, block);
@@ -156,20 +174,11 @@ BlockController.prototype.list = function(req, res) {
         }
 
         blocks.sort(function(a, b) {
-          return b.__height - a.__height;
+          return b.height - a.height;
         });
 
         var data = {
-          blocks: blocks.map(function(block) {
-            return {
-              height: block.__height,
-              size: block.toBuffer().length,
-              hash: block.hash,
-              time: block.header.time,
-              txlength: block.transactions.length,
-              poolInfo: self.getPoolInfo(block)
-            };
-          }),
+          blocks: blocks,
           length: blocks.length,
           pagination: {
             next: next,


### PR DESCRIPTION
The old code was reading 100-150MB of blocks per pageload, then parsing the blocks and all their transactions into javascript objects and then encoding that data back into binary block to get the block size.

I replaced it with code that gets the raw binary block data directly from bitcoind service and only parses the block headers and the coinbase transaction. Works much faster now.

It still unnecessarily reads the whole blocks from disk though. Would need to extend bitcore-node with an extra api call to only read headers, block size, number of transactions and coinbase to fix.