### PR TITLE
Use bitcore-lib as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
   "bitcoreNode": "lib",
   "dependencies": {
     "async": "*",
-    "bitcore-lib": "^0.13.7",
     "bitcore-message": "^1.0.1",
     "body-parser": "^1.13.3",
     "compression": "^1.6.1",
@@ -76,5 +75,8 @@
     "proxyquire": "^1.7.2",
     "should": "^8.3.1",
     "sinon": "^1.10.3"
+  },
+  "peerDependencies": {
+    "bitcore-lib": "^0.14.0"
   }
 }


### PR DESCRIPTION
One wrinkle to using the bitcore stack is the obvious need to have a singleton `bitcore-lib`.  The `bitcoin-lib` package hosts the `bitcoind` library and there are good reasons to not wanting to have multiple `bitcoind` instances running on the same machine.

However, I am not a fan of the runtime check and would rather have all packages be declaring `bitcoin-lib` in `peerDependencies`.  This way the enclosing package can specify whatever version of `bitcoin-lib` it wants and `npm` will inform user if there is an unmet dependency at _install_ time rather than _run_ time.

I have a working example of `bitcore-lib` running as a peerDependency at  [bitcore-docker-build](https://github.com/CaptEmulation/bitcore-docker-build) which is also running testnet at [bitcore.soapbubble.online](https://bitcore.soapbubble.online)

I also updated `bitcore-lib` to 0.14 because `bitcore-wallet-service` has already done so and I figured if it was good enough for `bitcoin-wallet-service` it's good enough for everything else :smile: 