### PR TITLE
Add CPFP endpoint

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -23,6 +23,7 @@ module.exports = function(app) {
   // Transaction routes
   var transactions = require('../app/controllers/transactions');
   app.get(apiPrefix + '/tx/:txid', transactions.show);
+  app.get(apiPrefix + '/tx/:txid/getcpfpfee', transactions.getCpfpFee);
   app.param('txid', transactions.transaction);
   app.get(apiPrefix + '/txs', transactions.list);
   app.post(apiPrefix + '/tx/send', transactions.send);


### PR DESCRIPTION
Dependent on PR https://github.com/bitpay/bitcoind-rpc/pull/24

Also, not sure whether it makes a difference with bitcore's bindings performance wise, but also related: https://github.com/bitcoin/bitcoin/issues/10300

Feature: Adds access to an endpoint that will let the user know how much additional fee to add to their transaction to ensure that unconfirmed parent transactions are confirmed along with it at the same fee rate.

This can be utilized by bitcore-wallet-service when deciding a fee if a user specifies to use CPFP.