### PR TITLE
/summary - provides summary information with batch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ Example response:
   /insight-api/addr/[:addr]/totalReceived
   /insight-api/addr/[:addr]/totalSent
   /insight-api/addr/[:addr]/unconfirmedBalance
+  
+  /insight-api/addrs/[:addrs]/summary
 ```
 The response contains the value in Satoshis.
 

--- a/lib/addresses.js
+++ b/lib/addresses.js
@@ -305,28 +305,21 @@ AddressController.prototype.multisummary = function(req, res) {
 
   async.eachLimit(addresses, 4, function(addr, next) {
 
-    self._address.getAddressSummary(addr, {}, function(err, summaries) {
+    self._address.getAddressSummary(addr, {}, function(err, summary) {
 
       if (err) {
         return next(err);
       }
 
-      if (addressesLeft-- > 0 && summaries.length > 0 && startedWriting) {
+      if (addressesLeft-- > 0 && startedWriting) {
         res.write(sep);
       }
-
-      for(var i = 0; i < summaries.length; i++) {
-        startedWriting = true;
-        if (summaries.length - 1 === i) {
-          sep = '';
-        }
-        cache.push(summaries[i]);
-        res.write(JSON.stringify(summaries[i]) + sep);
-      }
-
+      startedWriting = true;
+      sep = '';
+      cache.push(summary);
+      res.write(JSON.stringify(summary) + sep);
       sep = ',';
       next();
-
     });
 
   }, function(err) {
@@ -340,6 +333,7 @@ AddressController.prototype.multisummary = function(req, res) {
   });
 
 };
+
 
 
 AddressController.prototype.transformAddressHistoryForMultiTxs = function(txs, options, callback) {

--- a/lib/addresses.js
+++ b/lib/addresses.js
@@ -278,6 +278,70 @@ AddressController.prototype.multitxs = function(req, res) {
   });
 };
 
+// this call could take a while to run depending on what addresses are used
+// considering memory constraints,  we will streaming out the results for addresses
+// not necessarily in the order we received them
+
+
+AddressController.prototype.multisummary = function(req, res) {
+
+  var self = this;
+
+  var addresses;
+
+  if (_.isArray(req.addrs)) {
+    addresses = _.uniq(req.addrs);
+  } else {
+    addresses = _.compact(req.addrs.split(','));
+  }
+
+  var addressesLeft = addresses.length;
+  var startedWriting = false;
+  var cache = [];
+
+  res.write('[');
+
+  var sep = ',';
+
+  async.eachLimit(addresses, 4, function(addr, next) {
+
+    self._address.getAddressSummary(addr, {}, function(err, summaries) {
+
+      if (err) {
+        return next(err);
+      }
+
+      if (addressesLeft-- > 0 && summaries.length > 0 && startedWriting) {
+        res.write(sep);
+      }
+
+      for(var i = 0; i < summaries.length; i++) {
+        startedWriting = true;
+        if (summaries.length - 1 === i) {
+          sep = '';
+        }
+        cache.push(summaries[i]);
+        res.write(JSON.stringify(summaries[i]) + sep);
+      }
+
+      sep = ',';
+      next();
+
+    });
+
+  }, function(err) {
+
+      if (err) {
+        return self.common.handleErrors(err, res);
+      }
+
+      res.write(']');
+      res.end();
+  });
+
+};
+
+
 AddressController.prototype.transformAddressHistoryForMultiTxs = function(txs, options, callback) {
   var self = this;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -227,6 +227,8 @@ InsightAPI.prototype.setupRoutes = function(app) {
   app.get('/addr/:addr/totalReceived', this.cacheShort(), addresses.checkAddrs.bind(addresses), addresses.totalReceived.bind(addresses));
   app.get('/addr/:addr/totalSent', this.cacheShort(), addresses.checkAddrs.bind(addresses), addresses.totalSent.bind(addresses));
   app.get('/addr/:addr/unconfirmedBalance', this.cacheShort(), addresses.checkAddrs.bind(addresses), addresses.unconfirmedBalance.bind(addresses));
+ 
+  app.get('/addrs/:addrs/summary', this.cacheShort(), addresses.checkAddrs.bind(addresses), addresses.multisummary.bind(addresses));
 
   // Status route
   var status = new StatusController(this.node);


### PR DESCRIPTION
This call is useful if you need to retrieve summary information for multiple addresses (my use case). 
I'm developing a HD wallet and I find this quite useful to traverse various addres (i.e. reduced the time to complete the hd wallet init setup/discovery from 50 to 9 seconds). I'm not sure about the cost of this call... I basically need anything that can indicate if a bunch of addresses have ever had transactions.