### PR TITLE
add check to distinguish hash from height

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -174,6 +174,13 @@ BlockController.prototype.showRaw = function(req, res) {
 BlockController.prototype.blockIndex = function(req, res) {
   var self = this;
   var height = req.params.height;
+
+  let heightInt = parseInt(height, 10);
+  let heightRadixStr = heightInt.toString(10);
+  if (Number.isNaN(heightInt) || heightRadixStr !== height) {
+    throw 'invalid height provided';
+  }
+
   self._header.getBlockHeader(parseInt(height), function(err, info) {
     if (err || !info) {
       return self.common.handleErrors(err, res);

--- a/test/blocks.js
+++ b/test/blocks.js
@@ -153,7 +153,7 @@ describe('Blocks', function() {
         'blockHash': '0000000000000afa0c3c0afd450c793a1e300ec84cbe9555166e06132f19a8f7'
       };
 
-      var height = 533974;
+      var height = '533974';
 
       var req = {
         params: {


### PR DESCRIPTION
This fixes a bug where an invalid hash is interpreted as block height.