### PR TITLE
using .some instead of .any and .map instead of .pluck

### DIFF
--- a/lib/transactions.js
+++ b/lib/transactions.js
@@ -203,7 +203,7 @@ TxController.prototype.transformInvTransaction = function(transaction) {
     }
   }
 
-  var isRBF = _.any(_.pluck(transaction.inputs, 'sequence'), function(seq) {
+  var isRBF = _.some(_.map(transaction.inputs, 'sequence'), function(seq) {
     return seq < MAXINT - 1;
   });
 


### PR DESCRIPTION
According to the `lodash` [changelog](https://github.com/lodash/lodash/wiki/Changelog). 
```
- Removed _.pluck in favor of _.map with iteratee shorthand
- Removed _.any in favor of _.some
```

So I just fixed the code, it seems that these two functions are only used in `lib/transactions.js`. I'm not sure if there are any other function that will cause a `TypeError`.